### PR TITLE
feat(octagram): 引入基于语言模型的二字短词前置校验与惩罚机制

### DIFF
--- a/src/octagram.cc
+++ b/src/octagram.cc
@@ -16,6 +16,7 @@ struct GrammarConfig {
   double non_collocation_penalty = -12;
   double weak_collocation_penalty = -24;
   double rear_penalty = -18;
+  double unseen_two_char_penalty = 0.0;
 };
 
 const ResourceType kGramDbType = {"gram_db", "", ".gram"};
@@ -30,18 +31,13 @@ Octagram::Octagram(Config* config, OctagramComponent* component)
     } else {
       return;
     }
-    config->GetInt("grammar/collocation_max_length",
-                  &config_->collocation_max_length);
-    config->GetInt("grammar/collocation_min_length",
-                  &config_->collocation_min_length);
-    config->GetDouble("grammar/collocation_penalty",
-                     &config_->collocation_penalty);
-    config->GetDouble("grammar/non_collocation_penalty",
-                     &config_->non_collocation_penalty);
-    config->GetDouble("grammar/weak_collocation_penalty",
-                     &config_->weak_collocation_penalty);
-    config->GetDouble("grammar/rear_penalty",
-                     &config_->rear_penalty);
+    config->GetInt("grammar/collocation_max_length", &config_->collocation_max_length);
+    config->GetInt("grammar/collocation_min_length", &config_->collocation_min_length);
+    config->GetDouble("grammar/collocation_penalty", &config_->collocation_penalty);
+    config->GetDouble("grammar/non_collocation_penalty", &config_->non_collocation_penalty);
+    config->GetDouble("grammar/weak_collocation_penalty", &config_->weak_collocation_penalty);
+    config->GetDouble("grammar/rear_penalty", &config_->rear_penalty);
+    config->GetDouble("grammar/unseen_two_char_penalty", &config_->unseen_two_char_penalty);
   }
   if (!language.empty()) {
     db_ = component->GetDb(language);
@@ -110,29 +106,42 @@ double Octagram::Query(const string& context,
   if (!db_ || context.empty()) {
     return config_->non_collocation_penalty;
   }
+  
+  int n = (std::min)(grammar::kMaxEncodedUnicode, config_->collocation_max_length - 1);
+  int context_len = 0;
+  string context_query = grammar::encode(last_n_unicode(context, n, context_len), str_end(context));
+  int word_query_len = 0;
+  string word_query = grammar::encode(str_begin(word), first_n_unicode(word, n, word_query_len));
+  int cur_word_len = utf8::unchecked::distance(word.c_str(), word.c_str() + word.length());
+  
+  if (config_->unseen_two_char_penalty < 0.0 && cur_word_len == 2) {
+      bool exists_in_model = false;
+      GramDb::Match w_matches[GramDb::kMaxResults];
+      
+      int w_num = db_->Lookup("", word_query, w_matches); 
+      for (int i = 0; i < w_num; ++i) {
+          if (grammar::unicode_length(word_query, w_matches[i].length) == 2) {
+              exists_in_model = true; 
+              break;
+          }
+      }
+      
+      if (!exists_in_model) {
+          DLOG(INFO) << "UNSEEN 2-CHAR KILL: " << word;
+          return config_->unseen_two_char_penalty; 
+      }
+  }
+
   double result = config_->non_collocation_penalty;
   GramDb::Match matches[GramDb::kMaxResults];
-  int n = (std::min)(grammar::kMaxEncodedUnicode,
-                     config_->collocation_max_length - 1);
-  int context_len = 0;
-  string context_query = grammar::encode(
-      last_n_unicode(context, n, context_len),
-      str_end(context));
-  int word_query_len = 0;
-  string word_query = grammar::encode(
-      str_begin(word),
-      first_n_unicode(word, n, word_query_len));
+
   for (const char* context_ptr = str_begin(context_query);
        context_len > 0;
        --context_len, context_ptr = grammar::next_unicode(context_ptr)) {
     int num_results = db_->Lookup(context_ptr, word_query, matches);
-    DLOG(INFO) << "Lookup(" << context_ptr << " + " << word_query << ") returns "
-               << num_results << " results";
     for (auto i = 0; i < num_results; ++i) {
       const auto& match(matches[i]);
       const int match_len = grammar::unicode_length(word_query, match.length);
-      DLOG(INFO) << "match[" << match.length << "] = "
-                 << scale_value(match.value);
       const int collocation_len = context_len + match_len;
       if (update_result(result,
                         scale_value(match.value) +
@@ -141,28 +150,21 @@ double Octagram::Query(const string& context,
                                              match.length, word_query)
                          ? config_->collocation_penalty
                          : config_->weak_collocation_penalty))) {
-        DLOG(INFO) << "update: " << context << "[" << context_len << "] + "
-                   << word << "[" << match_len << "] = " << result;
       }
     }
   }
+  
   if (is_rear) {
-    int word_len = utf8::unchecked::distance(word.c_str(),
-                                             word.c_str() + word.length());
-    if (word_query_len == word_len &&
-        db_->Lookup(word_query, "$", matches) > 0 &&
-        update_result(result,
-                      scale_value(matches[0].value) + config_->rear_penalty)) {
-      DLOG(INFO) << "update: " << word << "$ / " << result;
+    int word_len = utf8::unchecked::distance(word.c_str(), word.c_str() + word.length());
+    if (word_query_len == word_len && db_->Lookup(word_query, "$", matches) > 0) {
+        update_result(result, scale_value(matches[0].value) + config_->rear_penalty);
     }
   }
-  DLOG(INFO) << "context = " << context << ", word = " << word
-             << " / " << result;
+
   return result;
 }
 
 OctagramComponent::OctagramComponent() {}
-
 OctagramComponent::~OctagramComponent() {}
 
 Octagram* OctagramComponent::Create(Config* config) {
@@ -177,7 +179,6 @@ GramDb* OctagramComponent::GetDb(const string& language) {
     the<GramDb> db =
         std::make_unique<GramDb>(resolver->ResolvePath(language));
     if (!db->Load()) {
-      LOG(ERROR) << "failed to load grammar database: " << language;
       return nullptr;
     }
     loaded = std::move(db);

--- a/src/octagram.cc
+++ b/src/octagram.cc
@@ -31,13 +31,20 @@ Octagram::Octagram(Config* config, OctagramComponent* component)
     } else {
       return;
     }
-    config->GetInt("grammar/collocation_max_length", &config_->collocation_max_length);
-    config->GetInt("grammar/collocation_min_length", &config_->collocation_min_length);
-    config->GetDouble("grammar/collocation_penalty", &config_->collocation_penalty);
-    config->GetDouble("grammar/non_collocation_penalty", &config_->non_collocation_penalty);
-    config->GetDouble("grammar/weak_collocation_penalty", &config_->weak_collocation_penalty);
-    config->GetDouble("grammar/rear_penalty", &config_->rear_penalty);
-    config->GetDouble("grammar/unseen_two_char_penalty", &config_->unseen_two_char_penalty);
+    config->GetInt("grammar/collocation_max_length",
+                  &config_->collocation_max_length);
+    config->GetInt("grammar/collocation_min_length",
+                  &config_->collocation_min_length);
+    config->GetDouble("grammar/collocation_penalty",
+                     &config_->collocation_penalty);
+    config->GetDouble("grammar/non_collocation_penalty",
+                     &config_->non_collocation_penalty);
+    config->GetDouble("grammar/weak_collocation_penalty",
+                     &config_->weak_collocation_penalty);
+    config->GetDouble("grammar/rear_penalty",
+                     &config_->rear_penalty);
+    config->GetDouble("grammar/unseen_two_char_penalty",
+                     &config_->unseen_two_char_penalty);
   }
   if (!language.empty()) {
     db_ = component->GetDb(language);
@@ -106,42 +113,50 @@ double Octagram::Query(const string& context,
   if (!db_ || context.empty()) {
     return config_->non_collocation_penalty;
   }
-  
-  int n = (std::min)(grammar::kMaxEncodedUnicode, config_->collocation_max_length - 1);
-  int context_len = 0;
-  string context_query = grammar::encode(last_n_unicode(context, n, context_len), str_end(context));
-  int word_query_len = 0;
-  string word_query = grammar::encode(str_begin(word), first_n_unicode(word, n, word_query_len));
-  int cur_word_len = utf8::unchecked::distance(word.c_str(), word.c_str() + word.length());
-  
-  if (config_->unseen_two_char_penalty < 0.0 && cur_word_len == 2) {
-      bool exists_in_model = false;
-      GramDb::Match w_matches[GramDb::kMaxResults];
-      
-      int w_num = db_->Lookup("", word_query, w_matches); 
-      for (int i = 0; i < w_num; ++i) {
-          if (grammar::unicode_length(word_query, w_matches[i].length) == 2) {
-              exists_in_model = true; 
-              break;
-          }
-      }
-      
-      if (!exists_in_model) {
-          DLOG(INFO) << "UNSEEN 2-CHAR KILL: " << word;
-          return config_->unseen_two_char_penalty; 
-      }
-  }
-
   double result = config_->non_collocation_penalty;
   GramDb::Match matches[GramDb::kMaxResults];
+  int n = (std::min)(grammar::kMaxEncodedUnicode,
+                     config_->collocation_max_length - 1);
+  int context_len = 0;
+  string context_query = grammar::encode(
+      last_n_unicode(context, n, context_len),
+      str_end(context));
+  int word_query_len = 0;
+  string word_query = grammar::encode(
+      str_begin(word),
+      first_n_unicode(word, n, word_query_len));
+
+  if (config_->unseen_two_char_penalty < 0.0) {
+    int cur_word_len = utf8::unchecked::distance(word.c_str(),
+                                                 word.c_str() + word.length());
+    if (cur_word_len == 2) {
+      bool exists_in_model = false;
+      GramDb::Match w_matches[GramDb::kMaxResults];
+      int w_num = db_->Lookup("", word_query, w_matches);
+      for (int i = 0; i < w_num; ++i) {
+        if (grammar::unicode_length(word_query, w_matches[i].length) == 2) {
+          exists_in_model = true;
+          break;
+        }
+      }
+      if (!exists_in_model) {
+        DLOG(INFO) << "UNSEEN 2-CHAR KILL: " << word;
+        return config_->unseen_two_char_penalty;
+      }
+    }
+  }
 
   for (const char* context_ptr = str_begin(context_query);
        context_len > 0;
        --context_len, context_ptr = grammar::next_unicode(context_ptr)) {
     int num_results = db_->Lookup(context_ptr, word_query, matches);
+    DLOG(INFO) << "Lookup(" << context_ptr << " + " << word_query << ") returns "
+               << num_results << " results";
     for (auto i = 0; i < num_results; ++i) {
       const auto& match(matches[i]);
       const int match_len = grammar::unicode_length(word_query, match.length);
+      DLOG(INFO) << "match[" << match.length << "] = "
+                 << scale_value(match.value);
       const int collocation_len = context_len + match_len;
       if (update_result(result,
                         scale_value(match.value) +
@@ -150,21 +165,28 @@ double Octagram::Query(const string& context,
                                              match.length, word_query)
                          ? config_->collocation_penalty
                          : config_->weak_collocation_penalty))) {
+        DLOG(INFO) << "update: " << context << "[" << context_len << "] + "
+                   << word << "[" << match_len << "] = " << result;
       }
     }
   }
-  
   if (is_rear) {
-    int word_len = utf8::unchecked::distance(word.c_str(), word.c_str() + word.length());
-    if (word_query_len == word_len && db_->Lookup(word_query, "$", matches) > 0) {
-        update_result(result, scale_value(matches[0].value) + config_->rear_penalty);
+    int word_len = utf8::unchecked::distance(word.c_str(),
+                                             word.c_str() + word.length());
+    if (word_query_len == word_len &&
+        db_->Lookup(word_query, "$", matches) > 0 &&
+        update_result(result,
+                      scale_value(matches[0].value) + config_->rear_penalty)) {
+      DLOG(INFO) << "update: " << word << "$ / " << result;
     }
   }
-
+  DLOG(INFO) << "context = " << context << ", word = " << word
+             << " / " << result;
   return result;
 }
 
 OctagramComponent::OctagramComponent() {}
+
 OctagramComponent::~OctagramComponent() {}
 
 Octagram* OctagramComponent::Create(Config* config) {
@@ -179,6 +201,7 @@ GramDb* OctagramComponent::GetDb(const string& language) {
     the<GramDb> db =
         std::make_unique<GramDb>(resolver->ResolvePath(language));
     if (!db->Load()) {
+      LOG(ERROR) << "failed to load grammar database: " << language;
       return nullptr;
     }
     loaded = std::move(db);


### PR DESCRIPTION
### 📝 提交说明 (Description)

#### 1. 背景与痛点 (Background & Motivation)
在实际使用中，用户的本地词库往往是一个“大杂烩”（如导入了各类庞大的百科词条）。对于由两个字组成的短片段，由于其极高的组合多样性和拼音碰撞率，给长句的连续推导带来了极大的不可控性。

目前引擎内部虽然可以通过长度控制来进行一定程度的干预，但仍存在难以剔除的“毒词”污染。举个真实的例子：
假设由于历史输入或词频原因，模型中 `[第一次] + [大]` 的转移权重意外大于了 `[第一次] + [打]`。当用户想输入“第一次打你”（di yi ci da ni）时，由于词库中存在“大鲵”这个生僻的百科词汇，引擎极易将其错误组合成 `[第一次] + [大鲵]`。
通过大数据统计固然能通过剪枝筛选掉一部分，但如果词库引入的脏数据过多，推导链条依然会走向失控。

#### 2. 核心原理 (Implementation Details)
本次提交提出了一种将 `.gram` 语言模型自身作为“天然白名单”的解决思路，本质上是对模型中两字短搭配的一个**前置判断拦截（Early Return）**。

执行逻辑如下：
当进入 `Query` 打分阶段时，系统首先拦截长度为 2 的候选词，并向模型进行一次独立的无上下文查询（Unigram Lookup）。
* **命中模型**：证明该词在主流语料中真实存在，直接放行，参与后续原版的 N-gram 循环打分算法。
* **未命中模型**：证明该词极大概率是词库乱拼或极度生僻的废词（如前文的“大鲵”），引擎将直接终止对其查库，并赋予配置的极低惩罚分，促使 Viterbi 算法在早期将其剪枝淘汰。

#### 3. 新增参数与使用方法 (Configuration & Usage)
为了保持配置的极简，本次提交在 `GrammarConfig` 中仅新增了一个“二合一”参数：
`unseen_two_char_penalty` （未收录两字词惩罚）

用户可在方案的 `grammar` 节点下进行如下配置：

```yaml
grammar:
  language: wanxiang-lts-zh-hans
  # ... 其他原有参数 ...
  
  # 对模型中不存在的 2 字候选词进行前置降维打击
  # 不设置或者设为0则不生效
  unseen_two_char_penalty: -50.0 
```

#### 4. 兼容性与收益 (Impact)
* **绝对向下兼容**：该参数默认值为 `0.0`。当参数为 `0.0` 时验证逻辑直接短路不生效，**与原版模型在执行流和性能上没有任何本质不同**。
* **精准的数据管理**：愿意对模型和输入法流进行精准数据管理的高阶用户，现在可以通过设置该参数（负数）大展身手，彻底屏蔽大词库带来的短词污染。
* **性能提升**：对于不在模型中的脏词，由于被前置拦截（Early Return），省去了原版复杂的 `for` 循环上下文查找，理论上进一步提升了长句打分的检索性能。

希望予以通过，谢谢！